### PR TITLE
README.md: fix link to podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ spin.
 
 To build the analyzer on your machine, you'll need the following tools:
 
-- [podman](https://podman.io/) configured to work in rootless mode
+- [podman](https://podman.io/) configured to work in [rootless mode](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md)
 - node.js and yarn
 - golang
 - the prerequisites to build `github.com/containers/image` (see

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ spin.
 
 To build the analyzer on your machine, you'll need the following tools:
 
-- [podman](podman.io/) configured to work in rootless mode
+- [podman](https://podman.io/) configured to work in rootless mode
 - node.js and yarn
 - golang
 - the prerequisites to build `github.com/containers/image` (see


### PR DESCRIPTION
The link to podman.io was interpreted relative to the page and clicking it resulted in a 404. This PR makes the link point to https://podman.io

While I was at it, I also added a link to a tutorial for setting up podman to run in rootless mode.